### PR TITLE
[depends] lz4 & lzo2 disable building executables

### DIFF
--- a/depends/common/lz4/02-disable-executables.patch
+++ b/depends/common/lz4/02-disable-executables.patch
@@ -1,0 +1,29 @@
+--- a/contrib/cmake_unofficial/CMakeLists.txt
++++ b/contrib/cmake_unofficial/CMakeLists.txt
+@@ -121,6 +121,7 @@
+   set(LZ4_LINK_LIBRARY lz4_static)
+ endif()
+ 
++if(ENABLE_EXECUTABLES)
+ # lz4
+ add_executable(lz4cli ${LZ4_CLI_SOURCES})
+ set_target_properties(lz4cli PROPERTIES OUTPUT_NAME lz4)
+@@ -130,6 +131,7 @@
+ add_executable(lz4c ${LZ4_CLI_SOURCES})
+ set_target_properties(lz4c PROPERTIES COMPILE_DEFINITIONS "ENABLE_LZ4C_LEGACY_OPTIONS")
+ target_link_libraries(lz4c ${LZ4_LINK_LIBRARY})
++endif()
+ 
+ # Extra warning flags
+ include (CheckCCompilerFlag)
+@@ -165,8 +167,10 @@
+ if(NOT LZ4_BUNDLED_MODE)
+   include(GNUInstallDirs)
+ 
++  if(ENABLE_EXECUTABLES)
+   install(TARGETS lz4cli lz4c
+     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
++  endif()
+   install(TARGETS ${LZ4_LIBRARIES_BUILT}
+     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"

--- a/depends/common/lzo2/01-disable-tests.patch
+++ b/depends/common/lzo2/01-disable-tests.patch
@@ -1,0 +1,46 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -127,6 +127,7 @@
+     endif()
+ endmacro()
+ # main test driver
++if(ENABLE_TESTS)
+ lzo_add_executable(lzotest  lzotest/lzotest.c)
+ # examples
+ lzo_add_executable(dict     examples/dict.c)
+@@ -148,6 +149,7 @@
+     add_executable(testmini minilzo/testmini.c minilzo/minilzo.c)
+     target_include_directories(testmini PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include/lzo") # needed for "lzoconf.h"
+ endif()
++endif()
+ 
+ # /***********************************************************************
+ # // compilation flags
+@@ -250,12 +252,14 @@
+ # // "make test"
+ # ************************************************************************/
+ 
++if(ENABLE_TESTS)
+ include(CTest)
+ add_test(NAME simple     COMMAND simple)
+ add_test(NAME testmini   COMMAND testmini)
+ add_test(NAME lzotest-01 COMMAND lzotest -mlzo   -n2  -q "${CMAKE_CURRENT_SOURCE_DIR}/COPYING")
+ add_test(NAME lzotest-02 COMMAND lzotest -mavail -n10 -q "${CMAKE_CURRENT_SOURCE_DIR}/COPYING")
+ add_test(NAME lzotest-03 COMMAND lzotest -mall   -n10 -q "${CMAKE_CURRENT_SOURCE_DIR}/include/lzo/lzodefs.h")
++endif()
+ 
+ # /***********************************************************************
+ # // "make install"
+@@ -285,10 +289,12 @@
+     )
+ endif()
+ 
++if(ENABLE_TESTS)
+ if(1)
+     set(f lzopack lzotest simple testmini) # examples
+     install(TARGETS ${f} DESTINATION "${CMAKE_INSTALL_FULL_LIBEXECDIR}/lzo/examples")
+ endif()
++endif()
+ 
+ if(PKG_CONFIG_FOUND)
+     configure_file(lzo2.pc.cmakein lzo2.pc @ONLY)


### PR DESCRIPTION
Windows UWP fails to build lz4 and lzo2 executables. They aren't needed for building libarchive, so don't build them.
Windows UWP still doesn't build, but now it fails at a later stage (building libarchive).