### PR TITLE
added: multi-volume support

### DIFF
--- a/vfs.libarchive/addon.xml.in
+++ b/vfs.libarchive/addon.xml.in
@@ -7,8 +7,8 @@
   <requires>@ADDON_DEPENDS@</requires>
   <extension
     point="kodi.vfs"
-    protocols="archive"
-    extensions=".7z|.tar.gz|.tar.bz2|.tar.xz|.zip|.tgz|.tbz2|.gz|.bz2|.xz"
+    protocols="archive|rar"
+    extensions=".7z|.tar.gz|.tar.bz2|.tar.xz|.zip|.rar|.tgz|.tbz2|.gz|.bz2|.xz"
     files="true"
     directories="true"
     filedirectories="true"


### PR DESCRIPTION
- suppress everything but first file in multi-volume rar archives
- re-add rar support
- make the add-on also accept the rar:// protocol for backwards compatibility

this should be the nail in the coffin for vfs.rar \o/