### PR TITLE
[fix] correct link order of libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,10 +29,10 @@ set(ARCHIVE_SOURCES src/ArchiveFile.cpp)
 set(DEPLIBS ${LibArchive_LIBRARIES}
             ${LIBLZMA_LIBRARIES}
             ${BZIP2_LIBRARIES}
+            ${OPENSSL_LIBRARIES}
             ${ZLIB_LIBRARIES}
             ${LZ4_LIBRARIES}
-            ${LZO2_LIBRARIES}
-            ${OPENSSL_LIBRARIES})
+            ${LZO2_LIBRARIES})
 
 add_definitions(-DLIBARCHIVE_STATIC)
 


### PR DESCRIPTION
link oder was wong at #12 as openssl uses zlib symbols

I didn't notice it as android linker ignored the unresolved symbols.
Tested now with ` -Wl,-undefined,error`