### PR TITLE
[debian] add missing dependency on libssl-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-vfs-libarchive
 Priority: extra
 Maintainer: Arne Morten Kvarving <spiff@kodi.tv>
 Build-Depends: debhelper (>= 9.0.0), cmake, libarchive-dev, kodi-addon-dev,
-               liblzo2-dev, liblz4-dev, liblzma-dev, libbz2-dev, zlib1g-dev
+               libssl-dev, liblzo2-dev, liblz4-dev, liblzma-dev, libbz2-dev, zlib1g-dev
 Standards-Version: 3.9.4
 Section: libs
 


### PR DESCRIPTION
openssl is required